### PR TITLE
fix: Loggroups are now using _ instead of -

### DIFF
--- a/templates/match.conf.j2
+++ b/templates/match.conf.j2
@@ -10,7 +10,7 @@
   @type cloudwatch_logs
   @log_level error
   region {{fluentd_cloudwatch_region}}
-  log_group_name {{project}}-{{env}}
+  log_group_name {{project}}_{{env}}
   log_stream_name {{file.name}}
   auto_create_stream true
   retention_in_day {{file.retention_in_day | default(default_retention_in_day, true) }}
@@ -46,7 +46,7 @@
   @type cloudwatch_logs
   @log_level error
   region {{fluentd_cloudwatch_region}}
-  log_group_name {{project}}-{{env}}
+  log_group_name {{project}}_{{env}}
   log_stream_name {{file.name}}
   auto_create_stream true
   retention_in_day {{file.retention_in_day | default(default_retention_in_day, true) }}


### PR DESCRIPTION
The previous version was done using `-` instead of `_`.
Our current specs in our Cycloid backend need to have the format `<project>_<env>`.
This patch fix the configuration file automatically generated