### PR TITLE
fix: Fix retention in day typo

### DIFF
--- a/templates/match.conf.j2
+++ b/templates/match.conf.j2
@@ -13,7 +13,7 @@
   log_group_name {{project}}-{{env}}
   log_stream_name {{file.name}}
   auto_create_stream true
-  retention_in_day {{file.retention_in_day | default(default_retention_in_day, true) }}
+  retention_in_days {{file.retention_in_day | default(default_retention_in_day, true) }}
 {% if file.tags is defined %}
   tags {{cycloid_tags|combine(file.tags)|to_json}}
 {% else %}
@@ -49,7 +49,7 @@
   log_group_name {{project}}-{{env}}
   log_stream_name {{file.name}}
   auto_create_stream true
-  retention_in_day {{file.retention_in_day | default(default_retention_in_day, true) }}
+  retention_in_days {{file.retention_in_day | default(default_retention_in_day, true) }}
 {% if file.tags is defined %}
   tags {{cycloid_tags|combine(file.tags)|to_json}}
 {% else %}


### PR DESCRIPTION
The keyword to set the retention of logs had a typo, so it wasn't working correctly.
It should now works as expected