### PR TITLE
ntp: Remove systemd check and install ntp

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,10 +1,8 @@
 ---
-- name: Check if time is synchronized (ntp test)
-  command: "timedatectl status"
-  register: time_synchronization
-  changed_when: false
-  tags:
-    - skip_ansible_lint
+- name: Install ntp daemon
+  package:
+    name: ntp
+    state: present
 
 # ulimit needs full shell
 - name: Register number of file descriptors
@@ -13,11 +11,6 @@
   changed_when: false
   tags:
     - skip_ansible_lint
-
-- name: Fail on desynchronized time
-  fail:
-    msg: "Synchronize time with NTP. Follow instructions at https://docs.fluentd.org/v0.14/articles/before-install"
-  when: "{{ not time_synchronization.stdout_lines[5].split(': ')[1]|bool }}"
 
 - name: Fail on too small number of file descriptors
   fail:


### PR DESCRIPTION
The previous check was completely tied to systemd and didn't work on older system.

This commit remove this check and instead, ensure ntp daemon to be installed to keep the time in sync.