### PR TITLE
systemd: Fix the systemd installation

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -46,7 +46,7 @@
   notify: restart td-agent
 
 - name: Check if systemd exists
-  stat: path=/etc/systemd/system/multi-user.target.wants/td-agent.service
+  stat: path=/lib/systemd/system/td-agent.service
   register: tdagent_service
 
 - name: Check if default td-agent exists
@@ -54,12 +54,12 @@
   register: tdagent_default
 
 - name: (systemd) Change the user who run td-agent
-  lineinfile: 'dest=/etc/systemd/system/multi-user.target.wants/td-agent.service backrefs=yes state=present regexp="^User=td-agent" line="User={{cycloid_user_fluentd}}"'
-  when: tdagent_service.stat.exists
+  lineinfile: 'dest=/lib/systemd/system/td-agent.service backrefs=yes state=present regexp="^User=td-agent" line="User={{cycloid_user_fluentd}}"'
+  when: tdagent_service.stat.exists and ansible_service_mgr == 'systemd'
 
 - name: (systemd) Force a daemon reload
   systemd: daemon_reload=yes
-  when: tdagent_service.stat.exists
+  when: tdagent_service.stat.exists and ansible_service_mgr == 'systemd'
   notify: restart td-agent
 
 - name: (default) Change the user who run td-agent


### PR DESCRIPTION
When td-agent is setup on a systemd service manager, it fails to configure itself to run as root.
Because the service file is located in /lib and not in /etc. Systemd populate itself the /etc/systemd folder based on the /lib/systemd folder.

So during the install, the file in /etc doesn't exist yet.

This patch should fix the issue by modifying directly the service at the source.