### PR TITLE
source: optionnal listen and forward

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,10 @@ cycloid_system_files_watched:
 # Define the user for fluentd to use
 cycloid_user_fluentd: root
 
+# Define a forward source (for example used for docker log driver)
+fluentd_forward: false
+fluentd_forward_port: 24224
+
 # paths to custom configuration templates
 fluentd_custom_conf: []
 

--- a/templates/source.conf.j2
+++ b/templates/source.conf.j2
@@ -1,5 +1,13 @@
 # {{ ansible_managed }}
 
+{% if fluentd_forward %}
+<source>
+  @type forward
+  port {{fluentd_forward_port}}
+  bind 0.0.0.0
+</source>
+{% endif %}
+
 {% for file in cycloid_files_watched %}
 <source>
   @type tail


### PR DESCRIPTION
When using docker log driver we need to be able to send logs via a port.
if fluentd_forward defined, a source listen port is configured.