### PR TITLE
prometheus: use fluent-plugin-prometheus 1.1.0 instead of latest

### DIFF
--- a/tasks/metrics.yml
+++ b/tasks/metrics.yml
@@ -2,6 +2,7 @@
 - name: Install prometheus plugin
   gem:
     name: "fluent-plugin-prometheus"
+    version: 1.1.0
     executable: /opt/td-agent/embedded/bin/fluent-gem
     state: present
     user_install: false


### PR DESCRIPTION
version 1.2.0 is causing issues

ref. https://trello.com/c/ugRZMcPB/949-ansible-fluentd-fluent-plugin-prometheus-v120-doesnt-seem-to-work