### PR TITLE
prometheus: use latest fluent-plugin-prometheus

### DIFF
--- a/tasks/metrics.yml
+++ b/tasks/metrics.yml
@@ -2,7 +2,6 @@
 - name: Install prometheus plugin
   gem:
     name: "fluent-plugin-prometheus"
-    version: 1.1.0
     executable: /opt/td-agent/embedded/bin/fluent-gem
     state: present
     user_install: false


### PR DESCRIPTION
The issue forcing us to fix the 1.1.0 version has been fixed.
ref. https://github.com/fluent/fluent-plugin-prometheus/issues/66