### PR TITLE
preflight.yml: dont fail on file desriptor

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -14,6 +14,6 @@
 
 
 - name: Fail on too small number of file descriptors
-  fail:
+  debug:
     msg: "Increase number of file descriptors to more than 1024. Follow instructions at https://docs.fluentd.org/v1.0/articles/before-install"
   when: file_descriptors.stdout|int < 1025


### PR DESCRIPTION
Remove fail to set debug. It shoulb only be a warning not a fail.
Filedescriptor is generaly set n systemd service description