### PR TITLE
Add 'gnupg' as fluentd dependencies (required for installation)

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,6 +1,7 @@
 ---
 fluentd_dependencies:
   - apt-transport-https
+  - gnupg
 
 fluentd_plugins_dependencies:
   - libcurl4-gnutls-dev

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,6 +1,7 @@
 ---
 fluentd_dependencies:
   - python3-libselinux
+  - gnupg
 
 fluentd_plugins_dependencies:
   - gcc

--- a/vars/ubuntu-20.yml
+++ b/vars/ubuntu-20.yml
@@ -3,6 +3,7 @@ fluentd_apt_repository: "https://packages.treasuredata.com/4/{{ ansible_distribu
 
 fluentd_dependencies:
   - apt-transport-https
+  - gnupg
 
 fluentd_plugins_dependencies:
   - libcurl4-gnutls-dev


### PR DESCRIPTION
The role uses GPG keys for the package repositories, `gnupg` might not be installed.