### PR TITLE
Make role working with ubuntu focal

### DIFF
--- a/vars/ubuntu-20.yml
+++ b/vars/ubuntu-20.yml
@@ -1,0 +1,9 @@
+---
+fluentd_apt_repository: "https://packages.treasuredata.com/4/{{ ansible_distribution|lower }}/{{ ansible_distribution_release|lower }}/"
+
+fluentd_dependencies:
+  - apt-transport-https
+
+fluentd_plugins_dependencies:
+  - libcurl4-gnutls-dev
+  - build-essential


### PR DESCRIPTION
First step before working on making td-agent v4 the default version.

Version matrix:
- ubuntu focal: v4
- ubuntu bionic: v3 and v4
- ubuntu xenial: v3 and v4
- debian buster: v3 and v4
- debian stretch: v3

ref. https://docs.fluentd.org/installation/install-by-deb